### PR TITLE
Fix typos

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -53,7 +53,7 @@ A blazing fast web directory scanner
 
   Possible values: `true`, `false`
 
-* `--insecure` — Unsecure mode, disables SSL certificate validation
+* `--insecure` — Insecure mode, disables SSL certificate validation
 
   Possible values: `true`, `false`
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -82,7 +82,7 @@ pub struct Opts {
     /// Interactive mode
     #[clap(short, long, env, hide_env = true)]
     pub interactive: bool,
-    /// Unsecure mode, disables SSL certificate validation
+    /// Insecure mode, disables SSL certificate validation
     #[clap(long, env, hide_env = true)]
     pub insecure: bool,
     /// Show response additional body information: "length", "hash", "headers_length", "headers_hash", "body", "headers"


### PR DESCRIPTION
Found via `codespell -H -L crate`