### PR TITLE
fix: support fractional values in wait option

### DIFF
--- a/src/runner/classic.rs
+++ b/src/runner/classic.rs
@@ -100,11 +100,11 @@ impl Classic {
             let response = client.execute(request).await;
             if let Some(ref wait) = opts.wait {
                 let (min, max) = wait.split_once('-').unwrap_or_default();
-                let min = min.parse::<u64>().unwrap_or(0);
-                let max = max.parse::<u64>().unwrap_or(0);
-                if max > 0 {
-                    let sleep_duration =
-                        Duration::from_secs(min + rand::random::<u64>() % (max - min));
+                let min = min.parse::<f64>().unwrap_or(0.0);
+                let max = max.parse::<f64>().unwrap_or(0.0);
+                if max > 0.0 {
+                    let random_wait = rand::random::<f64>() * (max - min) + min;
+                    let sleep_duration = Duration::from_secs_f64(random_wait);
                     tokio::time::sleep(sleep_duration).await;
                 } else {
                     progress.println(format!(

--- a/src/runner/recursive.rs
+++ b/src/runner/recursive.rs
@@ -207,11 +207,11 @@ impl Recursive {
             let response = client.execute(request).await;
             if let Some(ref wait) = opts.wait {
                 let (min, max) = wait.split_once('-').unwrap_or_default();
-                let min = min.parse::<f32>().unwrap_or(0.0);
-                let max = max.parse::<f32>().unwrap_or(0.0);
+                let min = min.parse::<f64>().unwrap_or(0.0);
+                let max = max.parse::<f64>().unwrap_or(0.0);
                 if max > 0.0 {
-                    let sleep_duration =
-                        Duration::from_secs_f32(rand::random::<f32>() * (max - min) + min);
+                    let random_wait = rand::random::<f64>() * (max - min) + min;
+                    let sleep_duration = Duration::from_secs_f64(random_wait);
                     tokio::time::sleep(sleep_duration).await;
                 } else {
                     progress.println(format!(


### PR DESCRIPTION
Fixes an issue with the `wait` option where fractional values (e.g., "0.5-1.5") are not properly handled. 

Currently, the code parses the wait values as `u64`, which doesn’t support floating-point numbers. This causes `min` and `max` to become 0 when decimals are used, leading to incorrect behavior.

**Changes made:**
- Updated parsing to use `f64` instead of `u64` to support fractional values.

This fix ensures that fractional wait ranges are properly supported.

Closes: https://github.com/cestef/rwalk/issues/8
