### PR TITLE
fix: prioritize CLI options over config with default fallback

### DIFF
--- a/src/cli/helpers.rs
+++ b/src/cli/helpers.rs
@@ -175,7 +175,7 @@ pub fn parse_method(s: &str) -> Result<String, String> {
     ];
     let s = s.to_uppercase();
     if methods.contains(&s.as_str()) {
-        Ok(s.to_string())
+        Ok(String::from_utf8_lossy(s.as_bytes()).to_string())
     } else {
         Err("Invalid HTTP method".to_string())
     }

--- a/src/cli/opts.rs
+++ b/src/cli/opts.rs
@@ -335,8 +335,10 @@ pub struct Opts {
     pub wait: Option<String>,
 }
 
-fn merge_overwrite<T>(a: &mut T, b: T) {
-    *a = b;
+fn merge_overwrite<T>(a: &mut Option<T>, b: Option<T>) {
+    if b.is_some() {
+        *a = b;
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]

--- a/src/cli/opts.rs
+++ b/src/cli/opts.rs
@@ -27,6 +27,7 @@ pub struct Opts {
         env,
         hide_env=true
     )]
+    #[merge(strategy = overwrite_option)]
     #[serde(default)]
     pub url: Option<String>,
 
@@ -50,6 +51,7 @@ pub struct Opts {
         hide_env = true,
         help_heading = Some("Mode")
     )]
+    #[merge(strategy = overwrite_option)]
     #[serde(default = "default_mode")]
     pub mode: Option<String>,
 
@@ -62,6 +64,7 @@ pub struct Opts {
         hide_env = true,
         help_heading = Some("Mode")
     )]
+    #[merge(strategy = overwrite_option)]
     #[serde(default = "default_depth")]
     pub depth: Option<usize>,
 
@@ -79,6 +82,7 @@ pub struct Opts {
 
     /// Number of threads to use
     #[clap(short, long, env, hide_env = true)]
+    #[merge(strategy = overwrite_option)]
     pub threads: Option<usize>,
 
     /// Follow redirects
@@ -89,11 +93,13 @@ pub struct Opts {
         env,
         hide_env = true,
     )]
+    #[merge(strategy = overwrite_option)]
     #[serde(default = "default_follow_redirects")]
     pub follow_redirects: Option<usize>,
 
     /// Output file
     #[clap(short, long, value_name = "FILE", env, hide_env = true)]
+    #[merge(strategy = overwrite_option)]
     pub output: Option<String>,
 
     /// Pretty format the output (only JSON)
@@ -104,20 +110,24 @@ pub struct Opts {
 
     /// Request timeout in seconds
     #[clap(long, env, hide_env = true, visible_alias = "to", help_heading = Some("Requests"))]
+    #[merge(strategy = overwrite_option)]
     #[serde(default = "default_timeout")]
     pub timeout: Option<usize>,
 
     /// User agent
     #[clap(short, long, env, hide_env = true, help_heading = Some("Requests"))]
+    #[merge(strategy = overwrite_option)]
     pub user_agent: Option<String>,
 
     /// HTTP method
     #[clap(short = 'X', long, value_parser = parse_method, env, hide_env=true, help_heading = Some("Requests"))]
+    #[merge(strategy = overwrite_option)]
     #[serde(default = "default_method")]
     pub method: Option<String>,
 
     /// Data to send with the request
     #[clap(short = 'D', long, env, hide_env = true, help_heading = Some("Requests"),)]
+    #[merge(strategy = overwrite_option)]
     pub data: Option<String>,
 
     /// Headers to send
@@ -134,6 +144,7 @@ pub struct Opts {
 
     /// Save file
     #[clap(short = 's', long, env, hide_env = true, help_heading = Some("Save"))]
+    #[merge(strategy = overwrite_option)]
     #[serde(default = "default_save_file")]
     pub save_file: Option<String>,
 
@@ -157,14 +168,17 @@ pub struct Opts {
 
     /// Configuration file
     #[clap(short, long, env, hide_env = true)]
+    #[merge(strategy = overwrite_option)]
     pub config: Option<String>,
 
     /// Request throttling (requests per second) per thread
     #[clap(long, env, hide_env = true)]
+    #[merge(strategy = overwrite_option)]
     pub throttle: Option<usize>,
 
     /// Max time to run (will abort after given time) in seconds
     #[clap(short = 'M', long, env, hide_env = true)]
+    #[merge(strategy = overwrite_option)]
     pub max_time: Option<usize>,
 
     /// Don't use colors
@@ -258,18 +272,22 @@ pub struct Opts {
 
     /// Override the default directory detection method with your own rhai script
     #[clap(long, help_heading = Some("Responses"), env, hide_env=true, visible_alias = "ds", visible_alias = "dir-script")]
+    #[merge(strategy = overwrite_option)]
     pub directory_script: Option<String>,
 
     /// Request file (.http, .rest)
     #[clap(long, value_name = "FILE", env, hide_env = true, visible_alias = "rf", help_heading = Some("Requests"),)]
+    #[merge(strategy = overwrite_option)]
     pub request_file: Option<String>,
 
     /// Proxy URL
     #[clap(short='P', long, help_heading = Some("Proxy"), value_name = "URL", env, hide_env=true)]
+    #[merge(strategy = overwrite_option)]
     pub proxy: Option<String>,
 
     /// Proxy username and password
     #[clap(long, help_heading = Some("Proxy"), value_name = "USER:PASS", env, hide_env=true)]
+    #[merge(strategy = overwrite_option)]
     pub proxy_auth: Option<String>,
 
     /// Allow subdomains to be scanned in spider mode
@@ -310,6 +328,7 @@ pub struct Opts {
 
     /// Generate completions for the specified shell
     #[clap(long, value_name = "SHELL", env, hide_env = true)]
+    #[merge(strategy = overwrite_option)]
     #[serde(default)]
     pub completions: Option<String>,
 
@@ -339,7 +358,15 @@ pub struct Opts {
 
     /// Random wait time range in seconds between requests, e.g. 0.5-1.5
     #[clap(long, help_heading = Some("Requests"), env, hide_env=true)]
+    #[merge(strategy = overwrite_option)]
     pub wait: Option<String>,
+}
+
+// Updates with the latest value, replacing the current one if provided.
+fn overwrite_option<T>(a: &mut Option<T>, b: Option<T>) {
+    if b.is_some() {
+        *a = b;
+    }
 }
 
 // Updates with the latest value, replacing the current one if provided.

--- a/src/cli/opts.rs
+++ b/src/cli/opts.rs
@@ -335,10 +335,8 @@ pub struct Opts {
     pub wait: Option<String>,
 }
 
-fn merge_overwrite<T>(a: &mut Option<T>, b: Option<T>) {
-    if b.is_some() {
-        *a = b;
-    }
+fn merge_overwrite<T>(a: &mut T, b: T) {
+    *a = b;
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,10 +21,10 @@ async fn main() -> Result<()> {
     utils::logger::init_logger();
     utils::init_panic()?;
 
-    // Start with default options
-    let mut opts = Opts::default();
+    // Step 1: Start with default values
+    let mut opts = Opts::default();  
 
-    // Load the configuration file first
+    // Step 2: Load configuration from file (overrides defaults)
     if let Some(home) = dirs::home_dir() {
         let p = home.join(Path::new(DEFAULT_CONFIG_PATH));
         if p.exists() {
@@ -32,19 +32,16 @@ async fn main() -> Result<()> {
             opts.merge(config_opts);
             log::debug!("Loaded config file: {}", p.display());
         } else {
-            log::debug!("Default config file not found: {}", p.display());
+            log::debug!("Config file not found: {}", p.display());
         }
     } else {
-        log::debug!("No home directory found, using default options");
+        log::debug!("No home directory found; skipping config file");
     }
 
-    // Parse the CLI options
+    // Step 3: Merge command-line arguments (override config and defaults)
     let cli_opts = Opts::parse();
-
-    // Merge the CLI options into the loaded configuration
     opts.merge(cli_opts);
-
-    log::debug!("Parsed options: {:#?}", opts);
+    log::debug!("Parsed CLI options: {:#?}", opts);
 
     if opts.open_config {
         // Open the config file in the default editor

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,25 +21,31 @@ async fn main() -> Result<()> {
     utils::logger::init_logger();
     utils::init_panic()?;
 
-    let mut opts = Opts::parse();
+    // Start with default options
+    let mut opts = Opts::default();
 
-    if let Some(p) = opts.config {
-        opts = Opts::from_path(p.clone()).await?;
-        log::debug!("Using config file: {}", p);
-    } else if let Some(home) = dirs::home_dir() {
-        log::debug!("Home directory found: {}", home.display());
+    // Load the configuration file first
+    if let Some(home) = dirs::home_dir() {
         let p = home.join(Path::new(DEFAULT_CONFIG_PATH));
         if p.exists() {
-            log::debug!("Config file found: {}", p.display());
-            let path_opts = Opts::from_path(p.clone()).await?;
-            opts.merge(path_opts);
-            log::debug!("Using config file: {}", p.display());
+            let config_opts = Opts::from_path(p.clone()).await?;
+            opts.merge(config_opts);
+            log::debug!("Loaded config file: {}", p.display());
+        } else {
+            log::debug!("Default config file not found: {}", p.display());
         }
     } else {
-        log::debug!("No home directory found");
+        log::debug!("No home directory found, using default options");
     }
 
+    // Parse the CLI options
+    let cli_opts = Opts::parse();
+
+    // Merge the CLI options into the loaded configuration
+    opts.merge(cli_opts);
+
     log::debug!("Parsed options: {:#?}", opts);
+
     if opts.open_config {
         // Open the config file in the default editor
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,31 +21,25 @@ async fn main() -> Result<()> {
     utils::logger::init_logger();
     utils::init_panic()?;
 
-    // Start with default options
-    let mut opts = Opts::default();
+    let mut opts = Opts::parse();
 
-    // Load the configuration file first
-    if let Some(home) = dirs::home_dir() {
+    if let Some(p) = opts.config {
+        opts = Opts::from_path(p.clone()).await?;
+        log::debug!("Using config file: {}", p);
+    } else if let Some(home) = dirs::home_dir() {
+        log::debug!("Home directory found: {}", home.display());
         let p = home.join(Path::new(DEFAULT_CONFIG_PATH));
         if p.exists() {
-            let config_opts = Opts::from_path(p.clone()).await?;
-            opts.merge(config_opts);
-            log::debug!("Loaded config file: {}", p.display());
-        } else {
-            log::debug!("Default config file not found: {}", p.display());
+            log::debug!("Config file found: {}", p.display());
+            let path_opts = Opts::from_path(p.clone()).await?;
+            opts.merge(path_opts);
+            log::debug!("Using config file: {}", p.display());
         }
     } else {
-        log::debug!("No home directory found, using default options");
+        log::debug!("No home directory found");
     }
 
-    // Parse the CLI options
-    let cli_opts = Opts::parse();
-
-    // Merge the CLI options into the loaded configuration
-    opts.merge(cli_opts);
-
     log::debug!("Parsed options: {:#?}", opts);
-
     if opts.open_config {
         // Open the config file in the default editor
 


### PR DESCRIPTION
### Problem
Options in the project can be provided from both config files and the CLI. The logic needs to prioritize CLI options when both are provided, while falling back to default values if neither the CLI nor config options are given.

### Solution
- CLI options are now privileged and will override config values when both are provided.
- If neither CLI nor config options are provided, default values are used.
- This ensures a clear priority order between config, CLI, and defaults.

### How to Test
1. Provide values via config and CLI, ensuring the CLI values take precedence.
2. Test cases where only the config or only the CLI is provided, ensuring the fallback behavior works as expected.
3. Verify that defaults are used when no values are provided.

### Additional Information
- This update ensures more flexible handling of options, with clear and consistent behavior across all sources (CLI, config, defaults).