### PR TITLE
fix: general bug fixes and improvements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,6 +336,7 @@ pub async fn _main(opts: Opts) -> Result<Tree<TreeData>> {
             url.clone(),
             opts.clone(),
             tree.clone(),
+            current_indexes.clone(),
             // We do not need to chunk the words here as it is chunked in the Classic struct
             words.clone(),
             threads,

--- a/src/runner/classic.rs
+++ b/src/runner/classic.rs
@@ -293,6 +293,8 @@ impl Classic {
                 .get_mut(i)
                 .ok_or(eyre!("Invalid index"))?;
             *entry += 1;
+
+            progress.inc(1);
         }
 
         Ok(())

--- a/src/runner/classic.rs
+++ b/src/runner/classic.rs
@@ -28,6 +28,7 @@ pub struct Classic {
     url: String,
     opts: Opts,
     tree: Arc<Mutex<Tree<TreeData>>>,
+    current_indexes: Arc<Mutex<HashMap<String, Vec<usize>>>>,
     words: HashMap<String, ParsedWordlist>,
     threads: usize,
 }
@@ -37,6 +38,7 @@ impl Classic {
         url: String,
         opts: Opts,
         tree: Arc<Mutex<Tree<TreeData>>>,
+        current_indexes: Arc<Mutex<HashMap<String, Vec<usize>>>>,
         words: HashMap<String, ParsedWordlist>,
         threads: usize,
     ) -> Self {
@@ -44,6 +46,7 @@ impl Classic {
             url,
             opts,
             tree,
+            current_indexes,
             words,
             threads,
         }
@@ -71,21 +74,35 @@ impl Classic {
     }
 
     async fn process_chunk(
+        root_url: String,
         chunk: Vec<String>,
         client: Client,
         progress: ProgressBar,
+        indexes: Arc<Mutex<HashMap<String, Vec<usize>>>>,
         tree: Arc<Mutex<Tree<TreeData>>>,
         opts: Opts,
         engine: Arc<rhai::Engine>,
+        i: usize,
     ) -> Result<()> {
-        for (index, url) in chunk.iter().enumerate() {
+        // Extract the index safely
+        let index = {
+            let mut indexes = indexes.lock();
+            *indexes
+                .get_mut(&root_url)
+                .ok_or(eyre!("Couldn't find indexes for the root node"))?
+                .get(i)
+                .ok_or(eyre!("Invalid index"))?
+        };
+
+        // Now it's safe to await
+        for url in &chunk[index..] {
             let mut url = url.clone();
             let t1 = Instant::now();
+
             if !opts.distributed.is_empty() {
                 let current = index % (opts.distributed.len() + 1);
                 if current != 0 {
                     let host_for_this_request = &opts.distributed[current - 1];
-
                     let parsed_url = url::Url::parse(&url)?;
                     url = format!(
                         "{}://{}{}",
@@ -95,8 +112,8 @@ impl Classic {
                     );
                 }
             }
-            let request = super::client::build_request(&opts, &url, &client)?;
 
+            let request = super::client::build_request(&opts, &url, &client)?;
             let response = client.execute(request).await;
             if let Some(ref wait) = opts.wait {
                 let (min, max) = wait.split_once('-').unwrap_or_default();
@@ -279,6 +296,18 @@ impl Classic {
                     }
                 }
             }
+            let mut indexes = indexes.lock(); // Lock the mutex
+
+            // Locking and working with the entry
+            let entry = indexes
+                .get_mut(&root_url)
+                .ok_or(eyre!("Couldn't find indexes for the root node"))?
+                .get_mut(i)
+                .ok_or(eyre!("Invalid index"))?;
+
+            // Now you can modify the entry
+            *entry += 1;
+
             progress.inc(1);
         }
 
@@ -299,15 +328,27 @@ impl Runner for Classic {
         }
         debug!("URLs: {:?}", urls);
 
-        let progress = ProgressBar::new(urls.len() as u64).with_style(
-            indicatif::ProgressStyle::default_bar()
-                .template(PROGRESS_TEMPLATE)?
-                .progress_chars(PROGRESS_CHARS),
-        );
-
-        progress.enable_steady_tick(Duration::from_millis(100));
         let chunks = urls.chunks(urls.len() / self.threads).collect::<Vec<_>>();
         let mut handles = Vec::with_capacity(chunks.len());
+
+        // Extract index safely and drop the lock early
+        let index = {
+            let mut indexes = self.current_indexes.lock();
+            indexes
+                .entry(self.url.clone())
+                .or_insert_with(|| vec![0; chunks.len()])
+                .clone()
+        };
+
+        let progress = ProgressBar::new(urls.len() as u64)
+            .with_style(
+                indicatif::ProgressStyle::default_bar()
+                    .template(PROGRESS_TEMPLATE)?
+                    .progress_chars(PROGRESS_CHARS),
+            )
+            .with_position(index.iter().sum::<usize>() as u64);
+
+        progress.enable_steady_tick(Duration::from_millis(100));
 
         let client = super::client::build(&self.opts)?;
         let mut engine = rhai::Engine::new();
@@ -320,15 +361,28 @@ impl Runner for Classic {
             }
         });
         let engine = Arc::new(engine);
-        for chunk in &chunks {
+        for (i, chunk) in chunks.iter().enumerate() {
+            let root_url = self.url.clone();
             let chunk = chunk.to_vec();
             let client = client.clone();
             let progress = progress.clone();
+            let indexes = self.current_indexes.clone();
             let tree = self.tree.clone();
             let opts = self.opts.clone();
             let engine = engine.clone();
             let res = tokio::spawn(async move {
-                Self::process_chunk(chunk, client, progress, tree, opts, engine).await
+                Self::process_chunk(
+                    root_url.clone(),
+                    chunk,
+                    client,
+                    progress,
+                    indexes,
+                    tree,
+                    opts,
+                    engine,
+                    i,
+                )
+                .await
             });
             handles.push(res);
         }

--- a/src/runner/classic.rs
+++ b/src/runner/classic.rs
@@ -305,7 +305,7 @@ impl Classic {
                 .get_mut(i)
                 .ok_or(eyre!("Invalid index"))?;
 
-            // Now you can modify the entry
+            // Increment the value at the specified index
             *entry += 1;
 
             progress.inc(1);

--- a/src/runner/recursive.rs
+++ b/src/runner/recursive.rs
@@ -195,10 +195,10 @@ impl Recursive {
                     );
                 }
             }
-            match url.ends_with('/') {
-                true => url.push_str(&word),
-                false => url.push_str(&format!("/{}", word)),
+            if !url.ends_with('/') && !word.starts_with('/') {
+                url.push('/');
             }
+            url.push_str(&word);
 
             let request = super::client::build_request(&opts, &url, &client)?;
 

--- a/src/runner/wordlists.rs
+++ b/src/runner/wordlists.rs
@@ -446,8 +446,11 @@ pub fn transformations(opts: &Opts, wordlists: &mut HashMap<String, ParsedWordli
 }
 
 pub fn compute_checksum(wordlists: &HashMap<String, ParsedWordlist>) -> String {
-    let to_compute = wordlists
-        .iter()
+    let mut entries: Vec<_> = wordlists.iter().collect();
+    entries.sort_by_key(|(key, _)| *key);
+
+    let to_compute = entries
+        .into_iter()
         .map(|(key, ParsedWordlist { words, .. })| format!("{}:{:?}", key, words.join(",")))
         .collect::<Vec<String>>()
         .join("|");

--- a/src/utils/tree.rs
+++ b/src/utils/tree.rs
@@ -265,7 +265,7 @@ pub fn from_save(
     words: HashMap<String, ParsedWordlist>,
 ) -> Result<Arc<Mutex<Tree<TreeData>>>> {
     if let Some(root) = &save.tree.clone().lock().root {
-        if opts.url.is_some() && root.lock().data.url != opts.url.clone().unwrap() {
+        if save.opts.url != opts.url {
             Err(color_eyre::eyre::eyre!(
                 "The URL of the saved state does not match the URL provided"
             ))


### PR DESCRIPTION
### Changes

1. **Prioritize CLI Config File Path Before Default**  
   The configuration loading logic now first checks if a config file path was specified via CLI options and loads that config if present. If no CLI config path is provided, it falls back to loading the default config file from the user’s home directory if it exists. Finally, all CLI options override the loaded config options. This ensures that specifying a config file via CLI properly overrides the default config location, matching expected behavior.

2. **Fixed URL Mismatch Issue**  
   The previous logic incorrectly compared the `root.data.url` with `opts.url`, leading to false mismatches when resuming a scan for `classic` mode. This has been fixed by comparing the full `opts.url` from the saved state.

   When resuming a scan with a fuzzing URL like:

   ```
   https://TARGET/api/v1/FUZ1Z/FUZ2Z
   ```

   The saved state (`.rwalk.json`) stores:

   ```json
   {
     "tree": {
       "root": {
         "data": {
           "url": "https://TARGET/api/v1/"
         }
       }
     },
     "opts": {
       "url": "https://TARGET/api/v1/FUZ1Z/FUZ2Z"
     }
   }
   ```

   The previous logic compared the `root.data.url` with `opts.url.clone().unwrap()`, leading to a false mismatch:

3. **Added `current_indexes` to Classic Mode**  
   In Classic Mode, the `--resume` option was not functioning correctly due to the absence of the `current_indexes` field. This functionality has been aligned with Recursive Mode, ensuring that the `resume` function works correctly by tracking the current state of indexes.

4. **Fixed Path Slash Stripping in Classic Mode**  
   In Classic Mode, URL paths were incorrectly stripped of slashes due to the use of `.replace(...)`. This has been corrected using `.strip_prefix(...)`, preserving proper path formatting like `/manager/html` instead of collapsing it to `managerhtml`.
   
   ![image](https://github.com/user-attachments/assets/116b9c3a-61a3-48ab-bc7a-d90330c32d5a)

5. **Fixed Double Slash Issue When Appending Words in Recursive Mode**  
   The original logic appended a slash before the word only if the base URL didn’t end with one. However, this caused double slashes when the word itself started with a slash. The new logic checks **both**: it only inserts a slash if the base URL doesn't end with one **and** the word doesn't start with one, preventing accidental `//` in the resulting URL.

6. **Ensured Stable Ordering for Wordlist Checksums**  
   When using multiple wordlists in Classic Mode, the unordered nature of `HashMap` caused inconsistent ordering of wordlists after saving and resuming scans. This resulted in different checksum values (`wordlist_checksums`) on resume, causing the scan to restart from scratch instead of continuing. The checksum computation now sorts the keys to guarantee stable order, preventing unnecessary scan restarts.

### Benchmark Comparison

Benchmarked `rwalk` (in classic mode) against `ffuf` and `gobuster` using the same wordlist and 150 threads.

Results show that `rwalk` achieves comparable or better wall time with significantly lower CPU usage (`User` + `System`), indicating efficient async I/O and minimal system load.

| Tool     | Mode     | Wall Time (avg) | User Time | System Time | Total CPU Time |
|----------|----------|-----------------|-----------|--------------|----------------|
| rwalk    | classic  | ~23.7s          | 3.19s     | 1.53s        | ~4.7s          |
| ffuf     | default  | ~25.5s          | 20.74s    | 4.10s        | ~24.8s         |
| gobuster | dir      | ~24.1s          | 5.82s     | 3.66s        | ~9.5s          |

`rwalk` provides efficient performance with significantly lower CPU overhead, making it ideal for high-performance fuzzing on resource-constrained systems.

![image](https://github.com/user-attachments/assets/0f28545a-876c-4710-bf32-649a6630507d)
