### PR TITLE
fix(cli): preserve case in wordlist path parsing and use canonical paths

### DIFF
--- a/crates/rwalk/src/cli/parse.rs
+++ b/crates/rwalk/src/cli/parse.rs
@@ -103,7 +103,9 @@ pub fn parse_key_or_keyval(s: &str) -> Result<(String, Option<String>)> {
     if parts.len() > 2 {
         return Err(syntax_error!((0, s.len()), s, "Expected at most one ':'"));
     }
-    Ok((parts[0].to_lowercase(), parts.get(1).map(|s| s.to_string())))
+    let key = parts[0].to_string(); // ← no lowercase here
+    let value = parts.get(1).map(|s| s.to_string());
+    Ok((key, value))
 }
 
 pub fn parse_wordlist(s: &str) -> Result<(String, String)> {


### PR DESCRIPTION
This PR improves handling of wordlist file paths in two ways:

1. **Preserve Case in Paths**  
   Previously, the CLI parser lowercased the path portion of `path[:key]`, causing failures on case-sensitive filesystems (e.g., Linux). Now the path is kept exactly as input, fixing these issues.

   ![image](https://github.com/user-attachments/assets/b5505452-4980-4b85-a2f8-f224299a2876)


2. **Resolve Canonical Paths**  
   We convert the provided path to its canonical form using `PathBuf::canonicalize()`. This resolves symlinks, relative components like `.` and `..`, and returns an absolute, normalized path. It ensures the file can be correctly found and accessed.

### Why?

- **Case preservation:** Lowercasing paths broke access to files with uppercase letters in their names or directories.
- **Canonicalization:** Without resolving to canonical paths, relative paths or symlinked files could fail to open or cause inconsistent behavior.

### Impact

- Fixes file-not-found errors caused by incorrect path casing.
- Enables correct handling of relative and symlinked paths.
- Makes wordlist file handling more robust and platform-compatible.
