### PR TITLE
fix: prevent automatic URL encoding by appending raw paths directly and remove manual URL decoding in display

### DIFF
--- a/crates/rwalk/src/utils/format.rs
+++ b/crates/rwalk/src/utils/format.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, fmt::Display};
+use std::fmt::Display;
 
 use owo_colors::OwoColorize;
 
@@ -8,7 +8,7 @@ pub fn response(response: &RwalkResponse, show: &[String]) -> String {
     format!(
         "{} {} {} {}",
         display_status_code(response.status as u16),
-        display_url(response.url.as_str()),
+        response.url.as_str(),
         display_time(response.time),
         {
             let showed = response.display_show(show);
@@ -19,10 +19,6 @@ pub fn response(response: &RwalkResponse, show: &[String]) -> String {
             }
         }
     )
-}
-
-fn display_url(url: &str) -> Cow<'_, str> {
-    urlencoding::decode(url).unwrap_or(url.into())
 }
 
 pub fn display_time(t: i64) -> String {
@@ -143,7 +139,7 @@ pub fn skip(response: &RwalkResponse, reason: SkipReason, show: &[String]) -> St
         "{} {} {} {} {} {}",
         "↷".blue(),
         response.status.dimmed(),
-        display_url(response.url.as_str()),
+        response.url.as_str(),
         display_time(response.time),
         format!("({})", reason).dimmed(),
         {

--- a/crates/rwalk/src/wordlist/mod.rs
+++ b/crates/rwalk/src/wordlist/mod.rs
@@ -45,13 +45,14 @@ impl Wordlist {
     }
 
     pub fn inject_into(&self, injector: &Injector<Task>, url: &Url, depth: usize) -> Result<()> {
-        let base_prefix = url[..Position::BeforePath]
-            .to_string()
-            .trim_end_matches('/')
-            .to_string(); // cache prefix once
+        let base_prefix = url[..Position::BeforePath].to_string();
 
         self.words.par_iter().try_for_each(|word| {
-            let full_url = format!("{}/{}", base_prefix, word);
+            let full_url = if base_prefix.ends_with('/') || word.starts_with('/') {
+                format!("{}{}", base_prefix.trim_end_matches('/'), word)
+            } else {
+                format!("{}/{}", base_prefix, word)
+            };
             injector.push(Task::new_recursive(full_url, depth));
             Ok(())
         })


### PR DESCRIPTION
- Updated URL injection logic to append raw wordlist paths directly as strings to the base URL instead of using `url` crate methods that automatically encode URL components. This preserves the exact input paths/queries, avoiding URL normalization issues and false positives during fuzzing (like `curl --path-as-is` behavior).
  
  ![image](https://github.com/user-attachments/assets/d054f6aa-266b-4793-a05a-36f36c7d9538)

- Removed manual URL decoding in `display_url` function to stop unnecessary URL encoding/decoding. This ensures the original input words are preserved and displayed as-is.

These changes together maintain input fidelity and improve accuracy in content discovery and fuzzing results.
