### PR TITLE
( `WIP` ) fix(urls): preserve trailing slashes and normalize URL joining

### DIFF
--- a/crates/rwalk/src/engine/pool.rs
+++ b/crates/rwalk/src/engine/pool.rs
@@ -429,12 +429,14 @@ impl WorkerPool {
                     } else {
                         self.pb.inc(1);
                     }
-                    if self.worker_config.filterer.filter(&response)? {
-                        self.worker_config.handler.handle(response.clone(), self)?;
-                        if self.config.bell {
-                            bell();
+                    if !results.contains_key(&response.url.to_string()) {
+                        if self.worker_config.filterer.filter(&response)? {
+                            results.insert(response.url.to_string(), response.clone());
+                            self.worker_config.handler.handle(response.clone(), self)?;
+                            if self.config.bell {
+                                bell();
+                            }
                         }
-                        results.insert(response.url.to_string(), response);
                     }
 
                     Ok::<(), crate::error::RwalkError>(())

--- a/crates/rwalk/src/utils/tree.rs
+++ b/crates/rwalk/src/utils/tree.rs
@@ -96,9 +96,23 @@ pub fn display_url_tree(base: &Url, urls: &DashMap<String, RwalkResponse>) {
         let url = entry.key();
         if let Ok(parsed_url) = Url::parse(url) {
             let path = parsed_url.path();
-            let components: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
-
-            insert_path(&mut root, &components, entry.value());
+            
+            // Collect into owned strings
+            let mut components: Vec<String> = path
+                .split('/')
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string())
+                .collect();
+    
+            if path.ends_with('/') && !components.is_empty() {
+                let last = components.len() - 1;
+                components[last].push('/');
+            }
+    
+            // Convert back to &str slices for insert_path
+            let components_ref: Vec<&str> = components.iter().map(|s| s.as_str()).collect();
+    
+            insert_path(&mut root, &components_ref, entry.value());
         }
     }
 

--- a/crates/rwalk/src/wordlist/mod.rs
+++ b/crates/rwalk/src/wordlist/mod.rs
@@ -49,7 +49,7 @@ impl Wordlist {
         self.words.par_iter().try_for_each(|word| {
             // Trim slashes to ensure exactly one slash between
             let base_trimmed = base_url.trim_end_matches('/');
-            let word_trimmed = word.trim_start_matches('/');
+            let word_trimmed = word.strip_prefix('/').unwrap_or(word);
     
             let full_url = format!("{}/{}", base_trimmed, word_trimmed);
     


### PR DESCRIPTION
## Description

This PR resolves three issues related to URL handling:

---

### 🛠 1. Preserve trailing slash in path components

When splitting URL paths, trailing slashes were previously lost — leading to loss of semantic distinction between endpoints like `/admin` and `/admin/`. These can represent different resources (e.g. route vs. directory), so we now preserve the trailing slash on the last component if it existed in the original path.

**Commit:**
```
fix(tree): preserve trailing slash in last path component

Some endpoints like `/admin` and `/admin/` can represent different resources
(e.g. a page vs. a directory). Stripping the trailing slash causes ambiguity
in routing or visualization. This change ensures the trailing slash is kept
on the last component when present in the original path.
```
![image](https://github.com/user-attachments/assets/180b1b74-ea11-41be-ae09-9e9bd3473bc7)

---

### 🔧 2. Normalize base URL and word joining

Incorrect handling of slashes between a base URL and a word (e.g. `/admin` + `login`) could result in malformed URLs like `/adminlogin` or `/admin//login`. This change trims the trailing slash from the base and the leading slash from the word before joining them with a single slash.

**Commit:**
```
fix(injector): ensure exactly one slash between base URL and word

Trim trailing slash from base URL and leading slash from word to prevent
double slashes or missing slashes in constructed URLs. This ensures
URLs like `/admin` and `login` combine correctly to `/admin/login`.
```

---

### 🚫 3. Avoid duplicate handling of the same URL in recursive mode

In recursive mode, the same URL could be inserted and handled multiple times. This introduces a check to avoid redundant processing and handler calls.

**Commit:**
```
fix(recursive): avoid duplicate URL handling by checking existing entries before insert
```
![image](https://github.com/user-attachments/assets/89333689-38f8-4fd0-8dc4-4c29afaad739)

---

## ✅ Result

- `/admin` + `login` → `/admin/login`
- `/admin/` + `login` → `/admin/login`
- `/admin` + `/login` → `/admin/login`
- `/admin/` + `/login` → `/admin/login`

- `/admin/` path will now be stored as `["admin/"]`
- `/admin` path will now be stored as `["admin"]`

This preserves semantic meaning, improves correctness when mapping URL paths and constructing tasks, and prevents unnecessary re-processing.

## 🧪 Test Coverage

Tested manually with paths:
- `/install/`
- `/install`
- `/api/`
- `/api/v1/`
- `/api/v1`

Confirmed correct insertion, dispatch, and uniqueness under recursion.
